### PR TITLE
Fix dining expiry times

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ argparse==1.2.1
 beautifulsoup4==4.3.2
 html5lib==0.999
 itsdangerous==0.24
-pymongo==2.7.2
 pytz==2014.7
 redis==2.10.3
 requests==2.4.3

--- a/server/dining.py
+++ b/server/dining.py
@@ -30,7 +30,7 @@ def retrieve_weekly_menu(venue_id):
 @app.route('/dining/daily_menu/<venue_id>', methods=['GET'])
 def retrieve_daily_menu(venue_id):
   now = datetime.datetime.today()
-  endDay = datetime.datetime(now.year, now.month, now.day) + datetime.timedelta(days=1)
+  end_time = datetime.datetime(now.year, now.month, now.day) + datetime.timedelta(hours=4)
   def get_data():
     return din.menu_daily(venue_id)["result_data"]
-  return cached_route('dining:venues:daily:%s' % venue_id, endDay-now, get_data)
+  return cached_route('dining:venues:daily:%s' % venue_id, end_time - now, get_data)


### PR DESCRIPTION
Adjust to 4 hour time period so the early morning can work in our favor. Having cache times be as long as possible is no longer a huge priority since we get so many hits.

Fixes #40 and pennlabs/penn-mobile-android#185.