### PR TITLE
Fix transit routes

### DIFF
--- a/server/transit.py
+++ b/server/transit.py
@@ -151,7 +151,7 @@ def routes_with_directions(route_data):
     and populates each stop['path_to'] with map waypoints between it and the previous
     stop. These are used to give full, correct paths when routing.
   """
-  def is_stop(waypoint, stop, epsilon=0.0001):
+  def is_stop(waypoint, stop, epsilon=0.0002):
       """Return whether waypoint is actually a stop based on a margin of error"""
       diff_latitude = abs(waypoint["Latitude"] - stop["Latitude"])
       diff_longitude = abs(waypoint["Longitude"] - stop["Longitude"])

--- a/server/transit.py
+++ b/server/transit.py
@@ -190,9 +190,8 @@ def populate_stop_info(stops):
               stop_dict[stop['title']]['routes'] = dict()
             stop_dict[stop['title']]['routes'][route['key']] = int(stop['stopOrder'])
     return stop_dict.values()
-  except Exception:
-    print "JSON Error in building stops"
-    return {}
+  except:
+    return {"error": "JSON error in building stops"}
 
 def populate_route_info():
   """

--- a/server/transit.py
+++ b/server/transit.py
@@ -128,13 +128,30 @@ def routes_with_directions(route_data):
       {
         route_name: "Route 1"
         stops: []
+      },
+      {
+        route_name: "PennBUS West"
+        stops: [
+          {
+            BusStopName: "The Quad, 3700 Spruce St.",
+            Latitude: 39.9,
+            Longitude: -75.2,
+            BusStopId: 29207,
+            order: 0,
+            path_to: [
+              {
+                Latitude: 39.95,
+                Longitude: -75.19
+              }
+            ]
+          }
+        ]
       }
     ]
     and populates each stop['path_to'] with map waypoints between it and the previous
     stop. These are used to give full, correct paths when routing.
   """
   for route in route_data:
-
     url = 'http://www.pennrides.com/Route/%d/Waypoints/' % pennride_id[route['route_name']]
     r = requests.get(url)
     all_waypoints = r.json()[0]

--- a/server/transit.py
+++ b/server/transit.py
@@ -151,6 +151,12 @@ def routes_with_directions(route_data):
     and populates each stop['path_to'] with map waypoints between it and the previous
     stop. These are used to give full, correct paths when routing.
   """
+  def is_stop(waypoint, stop, epsilon=0.0001):
+      """Return whether waypoint is actually a stop based on a margin of error"""
+      diff_latitude = abs(waypoint["Latitude"] - stop["Latitude"])
+      diff_longitude = abs(waypoint["Longitude"] - stop["Longitude"])
+      return diff_latitude + diff_longitude > epsilon
+
   for route in route_data:
     url = 'http://www.pennrides.com/Route/%d/Waypoints/' % pennride_id[route['route_name']]
     r = requests.get(url)
@@ -159,9 +165,7 @@ def routes_with_directions(route_data):
     for stop in route['stops']:
       stop['path_to'] = []
 
-      # margin of error is necessary to identify which waypoints are actually stops
-      while abs(all_waypoints[i]["Latitude"] - stop["Latitude"]) + abs(all_waypoints[i]["Longitude"] - stop["Longitude"])  > 0.0001:
-
+      while is_stop(all_waypoints[i], stop):
         stop['path_to'].append(all_waypoints[i])
         i += 1
         if i >= len(all_waypoints):


### PR DESCRIPTION
Currently, the main waypoints loop continues until it finds the waypoint which is actually the next stop. However, the previous epsilon was so strict and the ISC/pennrides data is so messy that it would not find it sometimes.
Increasing the epsilon to 0.0002 fixes the bug, and since stops are never very close to each other this should not be a problem.