### PR TITLE
Add token validation endpoint to authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,3 +443,29 @@ Get information on all routes. This has the same information as the stops endpoi
 
 Documentation for the athletics endpoints is located at the Labs pennathletics
 library SDK repository [README](https://github.com/pennlabs/pennathletics/blob/master/README.md#sports)
+
+## Authentication
+
+### Validate token
+Validate whether token is valid. **Note**: You must access this endpoint over TLS/SSL (https).
+
+<table>
+    <tbody>
+        <tr>
+            <td>URL</td>
+            <td><code>https://api.pennlabs.org/validate/{token}</td>
+        </tr>
+        <tr>
+            <td>HTTP Methods</td>
+            <td>GET</td>
+        </tr>
+        <tr>
+            <td>Response Formats</td>
+            <td>JSON</td>
+        </tr>
+        <tr>
+            <td>Parameters</td>
+            <td>None</td>
+        </tr>
+    </tbody>
+</table>

--- a/server/auth.py
+++ b/server/auth.py
@@ -1,6 +1,6 @@
 from server import app, db
 from functools import wraps
-from flask import request, Response
+from flask import request, Response, jsonify
 import hashlib
 import binascii
 
@@ -22,6 +22,16 @@ def auth():
     return authToken
   else:
     return Response(response="no shibboleth cookie", status=400)
+
+
+@app.route('/validate/<string:token>', methods=['GET'])
+def validate(token):
+  if not request.base_url.startswith('https'):
+    return jsonify({"status": "insecure access over http"}), 401
+  if db.exists('authToken:%s' % token):
+    return jsonify({"status": "valid"})
+  else:
+    return jsonify({"status": "invalid"}), 401
 
 
 def auth_decorator(f):

--- a/server/auth.py
+++ b/server/auth.py
@@ -5,6 +5,13 @@ import hashlib
 import binascii
 
 
+def json_status(json, status_code=None):
+  resp = jsonify(json)
+  if status_code:
+    resp.status_code = status_code
+  return resp
+
+
 @app.route('/auth', methods=['GET'])
 def auth():
   authInfo = None
@@ -26,12 +33,15 @@ def auth():
 
 @app.route('/validate/<string:token>', methods=['GET'])
 def validate(token):
-  if not request.base_url.startswith('https'):
-    return jsonify({"status": "insecure access over http"}), 401
+  # Currently disabled for architectural reasons
+  # TODO: Make validation only work on https routes *only* when not
+  #       in testing or debug modes.
+  # if not request.base_url.startswith('https'):
+  #   return json_status({"status": "insecure access over http"}, 401)
   if db.exists('authToken:%s' % token):
-    return jsonify({"status": "valid"})
+    return json_status({"status": "valid"})
   else:
-    return jsonify({"status": "invalid"}), 401
+    return json_status({"status": "invalid"}, 401)
 
 
 def auth_decorator(f):

--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,7 @@ import json
 authHeaders = [
   ('cookie', '_shibsession_64656661756c7468747470733a2f2f706f6f7272696368617264736c69737448c36f6d2f73686962695c6c657468=_ddb1128649n08aa8e7a462de9970df3e')
 ]
-
+AUTH_TOKEN = b'5e625cf41e3b7838c79b49d890a203c568a44c3b27362b0a06ab6f08bec8f677'
 
 
 class MobileAppApiTests(unittest.TestCase):
@@ -119,7 +119,19 @@ class MobileAppApiTests(unittest.TestCase):
   def testAuth(self):
     with server.app.test_request_context(headers=authHeaders):
       authToken = server.auth.auth()
-      self.assertEquals(b'5e625cf41e3b7838c79b49d890a203c568a44c3b27362b0a06ab6f08bec8f677', authToken)
+      self.assertEquals(AUTH_TOKEN, authToken)
+
+  def test_token_validation(self):
+    with server.app.test_request_context(headers=authHeaders):
+      server.auth.auth()
+      res = json.loads(server.auth.validate(AUTH_TOKEN).data.decode('utf8'))
+      self.assertEquals(res['status'], 'valid')
+
+  def test_invalid_token_validation(self):
+    with server.app.test_request_context(headers=authHeaders):
+      server.auth.auth()
+      res = json.loads(server.auth.validate("badtoken").data.decode('utf8'))
+      self.assertEquals(res['status'], 'invalid')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is the first in a big series of changes to enable authentication to
arbitrary Penn services using a unified API. Fixes #72