### PR TITLE
Modify laundry hall ids endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,30 @@ Return information on all laundry rooms
     </tbody>
 </table>
 
+### Hall id name location mapping
+Return a list of hall names, and their corresponding ids and locations.
+
+<table>
+    <tbody>
+        <tr>
+            <td>URL</td>
+            <td><code>https://api.pennlabs.org/laundry/halls/ids</code></td>
+        </tr>
+        <tr>
+            <td>HTTP Methods</td>
+            <td>GET</td>
+        </tr>
+        <tr>
+            <td>Response Formats</td>
+            <td>JSON</td>
+        </tr>
+        <tr>
+            <td>Parameters</td>
+            <td>None</td>
+        </tr>
+    </tbody>
+</table>
+
 ### Hall by hall_no
 Get information for a specific room by the hall_no. hall_no is given in the All Halls response.
 

--- a/tests.py
+++ b/tests.py
@@ -130,7 +130,7 @@ class MobileAppApiTests(unittest.TestCase):
                 'halls']
             self.assertTrue(len(res) > 45)
             self.assertTrue('English House' in res)
-            for hall, info in res.items():
+            for info in res.values():
                 for t in ['washers', 'dryers']:
                     self.assertTrue(info[t]['running'] >= 0)
                     self.assertTrue(info[t]['offline'] >= 0)


### PR DESCRIPTION
This fixes issue #102. The new format looks like this:
```json
{
  "halls": [
    {
      "hall_name": "Bishop White", 
      "id": 0
    }, 
    {
      "hall_name": "Chestnut Butcher", 
      "id": 1
    }, 
    {
      "hall_name": "Class of 1928 Fisher", 
      "id": 2
    }, 
    {
      "hall_name": "Craig", 
      "id": 3
    }, 
    {
      "hall_name": "DuBois", 
      "id": 4
    }, 
    ...
  ]
}