### PR TITLE
Trim whitespace from room IDs in Laundry

### DIFF
--- a/server/laundry.py
+++ b/server/laundry.py
@@ -185,7 +185,7 @@ def save_laundry_preferences():
     # delete old preferences for user
     LaundryPreference.query.filter_by(user_id=user.id).delete()
 
-    room_ids = [int(x) for x in room_ids.split(",")]
+    room_ids = [int(x.strip()) for x in room_ids.split(",")]
 
     for room_id in room_ids:
         laundry_preference = LaundryPreference(user_id=user.id, room_id=room_id)


### PR DESCRIPTION
The Android app is sending laundry room preferences data to the server as an ArrayList, but the ArrayList toString() method inserts ", " between each element of the ArrayList. As a result, the server is only able to parse the first element and all subsequent elements fail to be parsed because of the whitespace. This should fix the issue while retaining compatibility with the iOS version.